### PR TITLE
Faire mieux que soit en 2012… à l’élection de 2007

### DIFF
--- a/templates/prediction.html
+++ b/templates/prediction.html
@@ -117,7 +117,7 @@ et leurs propriétés statistiques sont utilisés.</p>
     <th>Probabilité...</th>
     <th>... de passer<br>au second tour</th>
     <th>... d'être troisième</th>
-    <th>... de faire mieux<br>que soi ou son<br>parti en 2012</th>
+    <th>... de faire mieux<br>que soi ou son<br>parti à l’élection précécédente</th>
 </tr>
 {% for c, p1, p2, p3 in prediction.individuals %}
 <tr>


### PR DESCRIPTION
Avec le template actuel, le site affiche la probabilité de faire mieux qu’en 2012 pour l’élection de 2007.

https://depuis1958.fr/2007/